### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-    "atom-linter": "^4.5.0",
-    "atom-package-deps": "^4.0.1"
+    "atom-linter": "4.5.x",
+    "atom-package-deps": "4.0.x"
   },
   "devDependencies": {
-    "coffeelint": "^1.14.2",
-    "eslint": "^2.1.0",
-    "babel-eslint": "^5.0.0",
-    "eslint-config-airbnb": "^6.0.2"
+    "coffeelint": "1.14.x",
+    "eslint": "2.1.x",
+    "babel-eslint": "5.0.x",
+    "eslint-config-airbnb": "6.0.x"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Changed to use a more forgiving dependency declaration. Now, Greenkeeper.io won't need to alert me whenever one of the dependencies has a patch version update.