### PR TITLE
Revert "Update eslint-plugin-import to version 2.0.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "eslint": "^3.6.1",
     "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-plugin-import": "^2.0.0"
+    "eslint-plugin-import": "^1.16.0"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Reverts AtomLinter/linter-reek#90

This shouldn't have been merged yet as it breaks the `peerDependency` of `eslint-config-airbnb-base@8`.