### PR TITLE
Use of reek JSON output format instead of Text output format

### DIFF
--- a/lib/linter-reek.js
+++ b/lib/linter-reek.js
@@ -7,9 +7,6 @@ import * as RuleHelpers from './rule-helpers';
 let helpers;
 let path;
 
-// Local variables
-const parseRegex = /\[(\d+)(?:, \d+)*\]:(.*) \[.+\/(.+).md\]/g;
-
 const loadDeps = () => {
   if (!helpers) {
     helpers = require('atom-linter');
@@ -17,6 +14,41 @@ const loadDeps = () => {
   if (!path) {
     path = require('path');
   }
+};
+
+const parseReekSyntaxError = (error, filePath) => {
+  const exceptionMessage = /Exception message:\s*(.*)/g.exec(error);
+  return [{
+    severity: 'error',
+    excerpt: exceptionMessage ? `linter-reek: ${exceptionMessage[1]}` : 'linter-reek: unexpected error',
+    location: {
+      file: filePath,
+      // first line of the file
+      position: [[0, 0], [0, Infinity]],
+    },
+  }];
+};
+
+const reekSmellToLinter = (smell, file, editor) => smell.lines.map(line => ({
+  url: smell.documentation_link,
+  description: () => RuleHelpers.getRuleMarkDown(smell.smell_type, smell.documentation_link),
+  excerpt: `${smell.smell_type}: ${smell.context} ${smell.message}`,
+  severity: 'warning',
+  location: {
+    file,
+    position: helpers.generateRange(editor, line - 1),
+  },
+}));
+
+const parseFromStd = (stdout) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    // continue regardless of error
+  }
+  if (typeof parsed !== 'object') { throw new Error(stdout); }
+  return parsed;
 };
 
 export default {
@@ -63,15 +95,19 @@ export default {
       grammarScopes: ['source.ruby', 'source.ruby.rails', 'source.ruby.rspec'],
       scope: 'file',
       lintsOnChange: false,
-      lint: async (TextEditor) => {
-        const filePath = TextEditor.getPath();
+      lint: async (editor) => {
+        const filePath = editor.getPath();
         if (!filePath) {
           // Somehow a TextEditor without a path was passed in
           return null;
         }
 
-        const fileText = TextEditor.getText();
+        const fileText = editor.getText();
         loadDeps();
+
+        const args = [];
+        args.push('--format', 'json');
+        args.push(filePath);
 
         const execOpts = {
           cwd: path.dirname(filePath),
@@ -80,41 +116,31 @@ export default {
 
         let output;
         try {
-          output = await helpers.exec(this.executablePath, [filePath], execOpts);
+          output = await helpers.exec(this.executablePath, args, execOpts);
         } catch (e) {
-          if (e.message !== 'Process execution timed out') throw e;
-          atom.notifications.addInfo('linter-reek: reek timed out', {
-            description: 'A timeout occured while executing reek, it could be due to lower resources '
-                         + 'or a temporary overload.',
-          });
-          return null;
+          if (e.message !== 'Process execution timed out') {
+            if (/Error: !!!/g.exec(e) == null) {
+              throw e;
+            } else {
+              return parseReekSyntaxError(e, filePath);
+            }
+          } else {
+            atom.notifications.addInfo('linter-reek: reek timed out', {
+              description: 'A timeout occured while executing reek, it could be due to lower resources '
+              + 'or a temporary overload.',
+            });
+            return null;
+          }
         }
 
-        if (TextEditor.getText() !== fileText) {
+        if (editor.getText() !== fileText) {
           // Editor contents have changed, tell Linter not to update
           return null;
         }
 
-        const messages = [];
-
-        let match = parseRegex.exec(output);
-        while (match !== null) {
-          const line = Number.parseInt(match[1], 10) - 1;
-          const rule = match[3];
-          const ruleLink = `https://github.com/troessner/reek/blob/master/docs/${rule}.md`;
-          messages.push({
-            url: ruleLink,
-            description: () => RuleHelpers.getRuleMarkDown(rule),
-            severity: 'warning',
-            excerpt: match[2],
-            location: {
-              file: filePath,
-              position: helpers.generateRange(TextEditor, line),
-            },
-          });
-          match = parseRegex.exec(output);
-        }
-        return messages;
+        return (parseFromStd(output) || []).map(
+          offense => reekSmellToLinter(offense, filePath, editor),
+        ).reduce((offenses, offense) => offenses.concat(offense));
       },
     };
   },

--- a/lib/linter-reek.js
+++ b/lib/linter-reek.js
@@ -140,7 +140,7 @@ export default {
 
         return (parseFromStd(output) || []).map(
           offense => reekSmellToLinter(offense, filePath, editor),
-        ).reduce((offenses, offense) => offenses.concat(offense));
+        ).reduce((offenses, offense) => offenses.concat(offense), []);
       },
     };
   },

--- a/lib/linter-reek.js
+++ b/lib/linter-reek.js
@@ -16,7 +16,7 @@ const loadDeps = () => {
   }
 };
 
-const parseReekSyntaxError = (error, filePath) => {
+const parseReekSyntaxError = (error, filePath, editor) => {
   const exceptionMessage = /Exception message:\s*(.*)/g.exec(error);
   return [{
     severity: 'error',
@@ -24,7 +24,7 @@ const parseReekSyntaxError = (error, filePath) => {
     location: {
       file: filePath,
       // first line of the file
-      position: [[0, 0], [0, Infinity]],
+      position: helpers.generateRange(editor, 0),
     },
   }];
 };
@@ -40,14 +40,13 @@ const reekSmellToLinter = (smell, file, editor) => smell.lines.map(line => ({
   },
 }));
 
-const parseFromStd = (stdout) => {
+const parseJSON = (stdout) => {
   let parsed;
   try {
     parsed = JSON.parse(stdout);
   } catch (error) {
-    // continue regardless of error
+    atom.notifications.addError('linter-reek: Unexpected error', { description: error.message });
   }
-  if (typeof parsed !== 'object') { throw new Error(stdout); }
   return parsed;
 };
 
@@ -119,10 +118,10 @@ export default {
           output = await helpers.exec(this.executablePath, args, execOpts);
         } catch (e) {
           if (e.message !== 'Process execution timed out') {
-            if (/Error: !!!/g.exec(e) == null) {
+            if (/Error: !!!/g.exec(e) === null) {
               throw e;
             } else {
-              return parseReekSyntaxError(e, filePath);
+              return parseReekSyntaxError(e, filePath, editor);
             }
           } else {
             atom.notifications.addInfo('linter-reek: reek timed out', {
@@ -138,7 +137,7 @@ export default {
           return null;
         }
 
-        return (parseFromStd(output) || []).map(
+        return (parseJSON(output) || []).map(
           offense => reekSmellToLinter(offense, filePath, editor),
         ).reduce((offenses, offense) => offenses.concat(offense), []);
       },

--- a/lib/rule-helpers.js
+++ b/lib/rule-helpers.js
@@ -17,7 +17,7 @@ export function takeWhile(source, predicate) {
 }
 
 // Retrieves style guide documentation with cached responses
-export async function getRuleMarkDown(rule) {
+export async function getRuleMarkDown(rule, ruleLink) {
   if (docsRuleCache.has(rule)) {
     const cachedRule = docsRuleCache.get(rule);
     if (new Date().getTime() >= cachedRule.expires) {
@@ -29,7 +29,7 @@ export async function getRuleMarkDown(rule) {
   }
 
   let rawRuleMarkdown;
-  const response = await fetch(`https://raw.githubusercontent.com/troessner/reek/master/docs/${rule}.md`);
+  const response = await fetch(ruleLink.replace('github.com', 'raw.githubusercontent.com').replace('/blob', ''));
   if (response.ok) {
     rawRuleMarkdown = await response.text();
   } else {

--- a/spec/linter-reek-spec.js
+++ b/spec/linter-reek-spec.js
@@ -20,7 +20,7 @@ describe('The reek provider for Linter', () => {
 
   it('checks a file with issues and reports the correct message', async () => {
     const excerpt = 'IrresponsibleModule: Dirty has no descriptive comment';
-    const url = 'https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md';
+    const url = 'https://github.com/troessner/reek/blob/v5.3.1/docs/Irresponsible-Module.md';
     const editor = await atom.workspace.open(badFile);
     const messages = await lint(editor);
 

--- a/spec/linter-reek-spec.js
+++ b/spec/linter-reek-spec.js
@@ -20,13 +20,13 @@ describe('The reek provider for Linter', () => {
 
   it('checks a file with issues and reports the correct message', async () => {
     const excerpt = 'IrresponsibleModule: Dirty has no descriptive comment';
-    const url = 'https://github.com/troessner/reek/blob/v5.3.1/docs/Irresponsible-Module.md';
+    const urlRegex = /https:\/\/github.com\/troessner\/reek\/blob\/v\d.+\/docs\/Irresponsible-Module.md/g;
     const editor = await atom.workspace.open(badFile);
     const messages = await lint(editor);
 
     expect(messages.length).toBe(1);
     expect(messages[0].severity).toEqual('warning');
-    expect(messages[0].url).toEqual(url);
+    expect(messages[0].url).toMatch(urlRegex);
     expect(messages[0].excerpt).toEqual(excerpt);
     expect(messages[0].location.file).toBe(badFile);
     expect(messages[0].location.position).toEqual([[0, 0], [0, 11]]);


### PR DESCRIPTION
Using the JSON output format simplifies a lot the smell forwarding to the linter.