### PR TITLE
Use the project's root dir to run reek

### DIFF
--- a/lib/linter-reek.js
+++ b/lib/linter-reek.js
@@ -113,7 +113,7 @@ export default {
         args.push(filePath);
 
         const execOpts = {
-          cwd: path.dirname(filePath),
+          cwd: atom.project.getPaths()[0],
           ignoreExitCode: true,
         };
 


### PR DESCRIPTION
This PR fixes this issue https://github.com/AtomLinter/linter-reek/issues/149

Currently, the plugin uses the current file's dir, but that breaks the rules directories rules defined at the `.reek.yml` config file [suggested for Rails projects](https://github.com/troessner/reek#working-with-rails):

```yml
directories:
  "app/controllers":
    IrresponsibleModule:
      enabled: false
    NestedIterators:
      max_allowed_nesting: 2
    UnusedPrivateMethod:
      enabled: false
    InstanceVariableAssumption:
      enabled: false
  "app/helpers":
    IrresponsibleModule:
      enabled: false
    UtilityFunction:
      enabled: false
  "app/mailers":
    InstanceVariableAssumption:
      enabled: false
  "app/models":
    InstanceVariableAssumption:
      enabled: false
```

Using the project's root path instead helps reek find directories that matches those config values. 